### PR TITLE
Small board support

### DIFF
--- a/site/about/index.html
+++ b/site/about/index.html
@@ -63,6 +63,9 @@
                                 Score points for each move in a successful joseki, with multipliers for combos, unique joseki finished, and total joseki in your library.
                                 Practice everyday to keep your streak.
                                 </p>
+                                <p class="card-text">
+                                On small screens, only the corner of the board will be shown. Only joseki that fit in the corner will be practiced.
+                                </p>
                             </div>
                         </div>
                     </div>

--- a/site/joseki.js
+++ b/site/joseki.js
@@ -7,6 +7,7 @@ const DELAY_MS = 250;
 const STORAGE_KEY = 'josekis';
 const BOARD_SIZE = 600;
 const SMALL_SIZE = 120;
+const SMALL_THRESH = 500;
 const FONT = 'Cabin Sketch';
 const TOKEN_KEY = 'token'
 const EMAIL_KEY = 'email';
@@ -35,6 +36,7 @@ const EMPTY_SCORE = {
     var currentEditGroupIndex;
     var groupHiddenState = {};
     var gridOption = false;
+    var smallBoard = false;
     var ghostStone;
     var lastMove;
     var msgObj;
@@ -96,7 +98,11 @@ const EMPTY_SCORE = {
             this.textBaseline="middle";
             this.textAlign="center";
             this.font = (board.stoneRadius * 4)+"px "+(board.font || "");
-            this.fillText(text, board.getX(9), board.getY(9));
+            if(smallBoard) {
+                this.fillText(text, board.getX(13), board.getY(5));
+            } else {
+                this.fillText(text, board.getX(9), board.getY(9));
+            }
         }}};
         board.addCustomObject(msgObj);
     }
@@ -293,6 +299,11 @@ const EMPTY_SCORE = {
         if(board) {
             board.setWidth(width);
         }
+        if (width < SMALL_THRESH) {
+            smallBoard = true;
+        } else {
+            smallBoard = false;
+        }
         return width;
     }
     window.addEventListener('resize', boardResize);
@@ -312,10 +323,15 @@ const EMPTY_SCORE = {
 
     function newBoard(element, width=boardResize(), grid=gridOption) {
         let adjust = grid ? 0.5 : 0;
+        let section = {top: 0, right: 0, bottom: 0, left: 0};
+        if (smallBoard) {
+            section = {top: 0, right: 0, bottom: 8.5, left: 8.5};
+        }
         let b = new WGo.Board(element, {
             width: width,
             background: "",
             font: FONT,
+            section: section,
         });
 
         if(grid){
@@ -396,9 +412,28 @@ const EMPTY_SCORE = {
             whiteBegins.push(wb);
         }
 
+        let all = original.concat(ltr, ttb, diag, whiteBegins);
+
+        // Filter joseki if board is small
+        let filtered = [];
+        if(smallBoard) {
+            filtered = all.filter((x) => {
+                let ret = true;
+                for (const mv of x.moves){
+                    let [x,y] = parseMove(mv);
+                    if(x != 'pass' && (x < 9 || y > 9)) {
+                        ret = false;
+                    }
+                }
+                return ret;
+            })
+        }else {
+            filtered = all;
+        }
+
         // Build move tree
         tree = {};
-        for (const joseki of original.concat(ltr, ttb, diag, whiteBegins)){
+        for (const joseki of filtered){
             let cur_tree = tree;
             for (const move of joseki.moves) {
                 if (! (move in cur_tree)) {

--- a/site/joseki.js
+++ b/site/joseki.js
@@ -7,7 +7,7 @@ const DELAY_MS = 250;
 const STORAGE_KEY = 'josekis';
 const BOARD_SIZE = 600;
 const SMALL_SIZE = 120;
-const SMALL_THRESH = 500;
+const SMALL_THRESH = 600;
 const FONT = 'Cabin Sketch';
 const TOKEN_KEY = 'token'
 const EMAIL_KEY = 'email';
@@ -97,7 +97,7 @@ const EMPTY_SCORE = {
             this.fillStyle = fillStyle;
             this.textBaseline="middle";
             this.textAlign="center";
-            this.font = (board.stoneRadius * 4)+"px "+(board.font || "");
+            this.font = (board.stoneRadius * 3)+"px "+(board.font || "");
             if(smallBoard) {
                 this.fillText(text, board.getX(13), board.getY(5));
             } else {


### PR DESCRIPTION
When the board gets too small (mobile) only display a corner, and prune the joseki to those that fit.